### PR TITLE
fix conditional logic by moving it to the block opener/closer checks

### DIFF
--- a/lib/html2haml/html/erb.rb
+++ b/lib/html2haml/html/erb.rb
@@ -59,9 +59,9 @@ module Haml
       # @param src [String] The source buffer
       # @param code [String] The Ruby statement to add to the buffer
       def add_stmt(src, code)
-        src << '</haml:block>' if has_code?(code) && block_closer?(code) || mid_block?(code)
+        src << '</haml:block>' if block_closer?(code) || mid_block?(code)
         src << '<haml:silent>' << h(code) << '</haml:silent>' unless code.strip == "end"
-        src << '<haml:block>' if has_code?(code) && block_opener?(code) || mid_block?(code)
+        src << '<haml:block>' if block_opener?(code) || mid_block?(code)
       end
 
       # Concatenates a Ruby expression that's printed to the document
@@ -120,6 +120,7 @@ module Haml
       # @param code [String] Ruby code to check
       # @return [Boolean]
       def block_opener?(code)
+        return unless has_code?(code)
         valid_ruby?(code + "\nend") ||
           valid_ruby?(code + "\nwhen foo\nend")
       end
@@ -130,6 +131,7 @@ module Haml
       # @param code [String] Ruby code to check
       # @return [Boolean]
       def block_closer?(code)
+        return unless has_code?(code)
         valid_ruby?("begin\n" + code)
       end
 
@@ -140,6 +142,7 @@ module Haml
       # @param code [String] Ruby code to check
       # @return [Boolean]
       def mid_block?(code)
+        return unless has_code?(code)
         return if valid_ruby?(code)
         valid_ruby?("if foo\n#{code}\nend") || # else, elsif
           valid_ruby?("begin\n#{code}\nend") || # rescue, ensure


### PR DESCRIPTION
The issue was with a precedence order problem.

the `&&` should have been an `and` but that would have been a confusing conditional so I moved the `has_code?` into the methods that test for blocks.
