### PR TITLE
Add an option to use Ruby 1.9 hash style

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See `html2haml --help`:
             --no-rhtml                   Deprecated; same as --no-erb.
         -x, --xhtml                      Parse the input using the more strict XHTML parser.
             --html-attributes            Use HTML style attributes instead of Ruby hash style.
+            --ruby19-hash                Use Ruby 1.9 hash style attributes instead of Ruby 1.8 hash style when possible.
         -E ex[:in]                       Specify the default external and internal character encodings.
         -s, --stdin                      Read input from standard input instead of an input file
             --trace                      Show a full traceback on error

--- a/lib/html2haml/exec.rb
+++ b/lib/html2haml/exec.rb
@@ -224,6 +224,10 @@ END
           @module_opts[:html_style_attributes] = true
         end
 
+        opts.on("--ruby19-hash", "Use Ruby 1.9 hash style attributes instead of Ruby 1.8 hash style when possible.") do
+          @module_opts[:ruby19_hash_style_attributes] = true
+        end
+
         unless RUBY_VERSION < "1.9"
           opts.on('-E ex[:in]', 'Specify the default external and internal character encodings.') do |encoding|
             external, internal = encoding.split(':')

--- a/lib/html2haml/html.rb
+++ b/lib/html2haml/html.rb
@@ -413,6 +413,12 @@ module Haml
         value = dynamic_attribute?(name, options) ? dynamic_attributes[name] : value.inspect
         if options[:html_style_attributes]
           "#{name}=#{value}"
+        elsif options[:ruby19_hash_style_attributes]
+          if name.index(/\W/)
+            "#{name.inspect} => #{value}"
+          else
+            "#{name}: #{value}"
+          end
         else
           name = name.index(/\W/) ? name.inspect : ":#{name}"
           "#{name} => #{value}"

--- a/test/html2haml_test.rb
+++ b/test/html2haml_test.rb
@@ -45,6 +45,13 @@ class Html2HamlTest < MiniTest::Unit::TestCase
       render('<meta http-equiv="Content-Type" content="text/html" />', :html_style_attributes => true))
   end
 
+  def test_should_have_ruby_19_hash_style_attributes
+    assert_equal('%input{name: "login", type: "text"}/',
+      render('<input type="text" name="login" />', :ruby19_hash_style_attributes => true))
+    assert_equal('%meta{content: "text/html", "http-equiv" => "Content-Type"}/',
+      render('<meta http-equiv="Content-Type" content="text/html" />', :ruby19_hash_style_attributes => true))
+  end
+
   def test_class_with_dot_and_hash
     assert_equal('%div{:class => "foo.bar"}', render("<div class='foo.bar'></div>"))
     assert_equal('%div{:class => "foo#bar"}', render("<div class='foo#bar'></div>"))


### PR DESCRIPTION
I'd like to add a new option to use the newer ruby hash style introduced in 1.9.
