### PR TITLE
Erubis and ruby_parser should be runtime dependencies

### DIFF
--- a/html2haml.gemspec
+++ b/html2haml.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'hpricot'
   gem.add_dependency 'haml', '>= 3.2.0.beta.1'
-  gem.add_development_dependency 'erubis'
-  gem.add_development_dependency 'ruby_parser'
+  gem.add_dependency 'erubis'
+  gem.add_dependency 'ruby_parser'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'


### PR DESCRIPTION
Erubis and ruby_parser were specified as development dependencies but are used in runtime. This commit changes them to runtime dependencies.
