### PR TITLE
Properly format empty nodes on their own lines

### DIFF
--- a/lib/html2haml/html.rb
+++ b/lib/html2haml/html.rb
@@ -319,7 +319,7 @@ module Haml
           if child.is_a?(::Hpricot::Text)
             if !child.to_s.include?("\n")
               text = child.to_haml(tabs + 1, options)
-              return output + " " + text.lstrip.gsub(/^\\/, '') unless text.chomp.include?("\n")
+              return output + " " + text.lstrip.gsub(/^\\/, '') unless text.chomp.include?("\n") || text.empty?
               return output + "\n" + text
             elsif ["pre", "textarea"].include?(name) ||
                 (name == "code" && parent.is_a?(::Hpricot::Elem) && parent.name == "pre")


### PR DESCRIPTION
## Original XML

``` xml
<book>
  <title>See Spot Run</title>
  <year>1942</year>
  <color></color>
  <weight>   </weight>
  <pages>102</pages>
</book>
```
## Without patch

Notice "weight" and "pages" on the same line

``` haml
%book
  %title See Spot Run
  %year 1942
  %color
  %weight   %pages 102
```
## With patch

Notice "weight" and "pages" cleaned up

``` haml
 %book
    %title See Spot Run
    %year 1942
    %color
    %weight
    %pages 102
```
