### PR TITLE
Update gem installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install html2haml
+    $ gem install html2haml --pre
 
 ## Usage
 


### PR DESCRIPTION
The gem won't install without the --pre due to the current state of the gem as 1.0.0.beta.1.
