### PR TITLE
Fix failing tests in nokogiri update

### DIFF
--- a/lib/html2haml/html.rb
+++ b/lib/html2haml/html.rb
@@ -198,7 +198,7 @@ module Haml
       def content_without_cdata_tokens
         content.
           gsub(/^\s*<!\[CDATA\[\n/,"").
-          gsub(/^\s*]]>\n/, "")
+          gsub(/^\s*\]\]>\n/, "")
       end
     end
 


### PR DESCRIPTION
I've whittled the failing tests down to two:

```
  1) Failure:
test_non_inline_erb(ErbTest) [/Users/stefan/Projects/html2haml/test/erb_test.rb:31]:
--- expected
+++ actual
@@ -1,2 +1 @@
-"%p
-  = foo"
+"%p= foo"


  2) Failure:
test_script_tag_with_html_escaped_javascript(Html2HamlTest) [/Users/stefan/Projects/html2haml/test/html2haml_test.rb:154]:
--- expected
+++ actual
@@ -1,4 +1,4 @@
 ":javascript
   function foo() {
-      return \"12\" & \"13\";
+      return \"12\" &amp; \"13\";
   }"
```

Failure 2 seems like a really strange test case and I wanted to ask you what the motivation for it was. Is it a bad test?

And I am stuck trying to figure out Failure 1. If you have any insight, let me know.
