### PR TITLE
Fixed ruby2.0 Hash[nil] deprecated warinigs

### DIFF
--- a/lib/html2haml/html.rb
+++ b/lib/html2haml/html.rb
@@ -344,14 +344,20 @@ module Haml
       def dynamic_attributes
         @dynamic_attributes ||= begin
           Hash[attr_hash.map do |name, value|
-            next if value.empty?
-            full_match = nil
-            ruby_value = value.gsub(%r{<haml:loud>\s*(.+?)\s*</haml:loud>}) do
-              full_match = $`.empty? && $'.empty?
-              CGI.unescapeHTML(full_match ? $1: "\#{#{$1}}")
+            if value.empty?
+              [nil, nil]
+            else
+              full_match = nil
+              ruby_value = value.gsub(%r{<haml:loud>\s*(.+?)\s*</haml:loud>}) do
+                full_match = $`.empty? && $'.empty?
+                CGI.unescapeHTML(full_match ? $1: "\#{#{$1}}")
+              end
+              if ruby_value == value
+                [nil, nil]
+              else
+                [name, full_match ? ruby_value : %("#{ruby_value}")]
+              end
             end
-            next if ruby_value == value
-            [name, full_match ? ruby_value : %("#{ruby_value}")]
           end]
         end
       end


### PR DESCRIPTION
In ruby 2.0, Hash[nil] occurs following warnings.

```
dynamic.rb:3: warning: wrong element type nil at 0 (expected array)
dynamic.rb:3: warning: ignoring wrong elements is deprecated,  remove them explicitly
dynamic.rb:3: warning: this causes ArgumentError in the next release
```

This commit fixes it.
