### PR TITLE
Gem ruby_parser requirement is lowered

### DIFF
--- a/html2haml.gemspec
+++ b/html2haml.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'nokogiri', '~> 1.6.0'
   gem.add_dependency 'erubis', '~> 2.7.0'
-  gem.add_dependency 'ruby_parser', '~> 3.6.2'
+  gem.add_dependency 'ruby_parser', '>= 3.5'
   gem.add_dependency 'haml', '~> 4.0.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'minitest', '~> 4.4.0'


### PR DESCRIPTION
I have trouble merging into the bundle of gems for my rails project. The resulting Gemfile.lock is below: 

```
GIT
  remote: https://github.com/dima4p/html2haml.git
  revision: b57c9d461583abf69410797a8a4d2ef5bf3ac2f4
  specs:
    html2haml (2.0.0.beta.2)
      erubis (~> 2.7.0)
      haml (~> 4.0.0)
      nokogiri (~> 1.6.0)
      ruby_parser (>= 3.5)

GEM
  remote: https://rubygems.org/
  specs:
    actionmailer (4.2.0)
      actionpack (= 4.2.0)
      actionview (= 4.2.0)
      activejob (= 4.2.0)
      mail (~> 2.5, >= 2.5.4)
      rails-dom-testing (~> 1.0, >= 1.0.5)
    actionpack (4.2.0)
      actionview (= 4.2.0)
      activesupport (= 4.2.0)
      rack (~> 1.6.0)
      rack-test (~> 0.6.2)
      rails-dom-testing (~> 1.0, >= 1.0.5)
      rails-html-sanitizer (~> 1.0, >= 1.0.1)
    actionview (4.2.0)
      activesupport (= 4.2.0)
      builder (~> 3.1)
      erubis (~> 2.7.0)
      rails-dom-testing (~> 1.0, >= 1.0.5)
      rails-html-sanitizer (~> 1.0, >= 1.0.1)
    active_model_serializers (0.9.2)
      activemodel (>= 3.2)
    active_record_model_and_rspec_enhanced_templates (1.0.4)
    activejob (4.2.0)
      activesupport (= 4.2.0)
      globalid (>= 0.3.0)
    activemodel (4.2.0)
      activesupport (= 4.2.0)
      builder (~> 3.1)
    activerecord (4.2.0)
      activemodel (= 4.2.0)
      activesupport (= 4.2.0)
      arel (~> 6.0)
    activesupport (4.2.0)
      i18n (~> 0.7)
      json (~> 1.7, >= 1.7.7)
      minitest (~> 5.1)
      thread_safe (~> 0.3, >= 0.3.4)
      tzinfo (~> 1.1)
    addressable (2.3.6)
    advanced_haml_scaffold_generator (1.0.0)
    annotate (2.6.5)
      activerecord (>= 2.3.0)
      rake (>= 0.8.7)
    arel (6.0.0)
    ast (2.0.0)
    astrolabe (1.3.0)
      parser (>= 2.2.0.pre.3, < 3.0)
    authlogic (3.4.4)
      activerecord (>= 3.2)
      activesupport (>= 3.2)
      request_store (~> 1.0)
      scrypt (~> 1.2)
    brakeman (2.6.2)
      erubis (~> 2.6)
      fastercsv (~> 1.5)
      haml (>= 3.0, < 5.0)
      highline (~> 1.6.20)
      multi_json (~> 1.2)
      ruby2ruby (~> 2.1.1)
      ruby_parser (~> 3.5.0)
      sass (~> 3.0)
      slim (>= 1.3.6, < 3.0)
      terminal-table (~> 1.4)
    builder (3.2.2)
    cancancan (1.9.2)
    capistrano (3.3.5)
      capistrano-stats (~> 1.1.0)
      i18n
      rake (>= 10.0.0)
      sshkit (~> 1.3)
    capistrano-bundler (1.1.3)
      capistrano (~> 3.1)
      sshkit (~> 1.2)
    capistrano-passenger (0.0.1)
      capistrano (~> 3.0)
    capistrano-rails (1.1.2)
      capistrano (~> 3.1)
      capistrano-bundler (~> 1.1)
    capistrano-rvm (0.1.2)
      capistrano (~> 3.0)
      sshkit (~> 1.2)
    capistrano-stats (1.1.1)
    capybara (2.4.4)
      mime-types (>= 1.16)
      nokogiri (>= 1.3.3)
      rack (>= 1.0.0)
      rack-test (>= 0.5.4)
      xpath (~> 2.0)
    celluloid (0.16.0)
      timers (~> 4.0.0)
    chunky_png (1.3.3)
    cliver (0.3.2)
    coderay (1.1.0)
    coffee-rails (4.1.0)
      coffee-script (>= 2.2.0)
      railties (>= 4.0.0, < 5.0)
    coffee-script (2.3.0)
      coffee-script-source
      execjs
    coffee-script-source (1.8.0)
    colorize (0.7.5)
    compass (1.0.1)
      chunky_png (~> 1.2)
      compass-core (~> 1.0.1)
      compass-import-once (~> 1.0.5)
      rb-fsevent (>= 0.9.3)
      rb-inotify (>= 0.9)
      sass (>= 3.3.13, < 3.5)
    compass-core (1.0.1)
      multi_json (~> 1.0)
      sass (>= 3.3.0, < 3.5)
    compass-import-once (1.0.5)
      sass (>= 3.2, < 3.5)
    compass-rails (2.0.1)
      compass (~> 1.0.0)
    database_cleaner (1.3.0)
    delayed_job (4.0.6)
      activesupport (>= 3.0, < 5.0)
    delayed_job_active_record (4.0.3)
      activerecord (>= 3.0, < 5.0)
      delayed_job (>= 3.0, < 4.1)
    diff-lcs (1.2.5)
    docile (1.1.5)
    email_spec (1.6.0)
      launchy (~> 2.1)
      mail (~> 2.2)
    erubis (2.7.0)
    execjs (2.2.2)
    factory_girl (4.5.0)
      activesupport (>= 3.0.0)
    factory_girl_fixtures_template (1.0.1)
    factory_girl_rails (4.5.0)
      factory_girl (~> 4.5.0)
      railties (>= 3.0.0)
    faker (1.4.3)
      i18n (~> 0.5)
    fancy-buttons (1.2.0)
      compass (>= 0.11)
    faraday (0.9.0)
      multipart-post (>= 1.2, < 3)
    fastercsv (1.5.5)
    ffi (1.9.6)
    ffi-compiler (0.1.3)
      ffi (>= 1.0.0)
      rake
    font-awesome-rails (4.2.0.0)
      railties (>= 3.2, < 5.0)
    formatador (0.2.5)
    geonames_api (0.1.6)
      activesupport
      rubyzip
      tzinfo
    get_process_mem (0.2.0)
    globalid (0.3.0)
      activesupport (>= 4.1.0)
    guard (2.10.5)
      formatador (>= 0.2.4)
      listen (~> 2.7)
      lumberjack (~> 1.0)
      nenv (~> 0.1)
      pry (>= 0.9.12)
      thor (>= 0.18.1)
    guard-compat (1.2.0)
    guard-rspec (4.5.0)
      guard (~> 2.1)
      guard-compat (~> 1.1)
      rspec (>= 2.99.0, < 4.0)
    guard-rubocop (1.2.0)
      guard (~> 2.0)
      rubocop (~> 0.20)
    haml (4.0.6)
      tilt
    haml-rails (0.6.0)
      actionpack (>= 4.0.1)
      activesupport (>= 4.0.1)
      haml (>= 3.1, < 5.0)
      html2haml (>= 1.0.1)
      railties (>= 4.0.1)
    highline (1.6.21)
    hike (1.2.3)
    hitimes (1.2.2)
    i18n (0.7.0)
    i18n_scaffold_controller_template (1.0.4)
    i18n_scaffold_generator (1.0.3)
    i18n_yaml_sorter (0.2.0)
    jbuilder (2.2.6)
      activesupport (>= 3.0.0, < 5)
      multi_json (~> 1.2)
    jbuilder_rspec_generator (1.0.7)
      multi_json
    jquery-migrate-rails (1.2.1)
    jquery-placeholder-rails (2.0.7)
    jquery-rails (4.0.2)
      rails-dom-testing (~> 1.0)
      railties (>= 4.2.0)
      thor (>= 0.14, < 2.0)
    jquery-ui-rails (5.0.3)
      railties (>= 3.2.16)
    json (1.8.1)
    kaminari (0.16.1)
      actionpack (>= 3.0.0)
      activesupport (>= 3.0.0)
    kgio (2.9.2)
    launchy (2.4.3)
      addressable (~> 2.3)
    letter_opener (1.3.0)
      launchy (~> 2.2)
    libv8 (3.16.14.7)
    listen (2.8.4)
      celluloid (>= 0.15.2)
      rb-fsevent (>= 0.9.3)
      rb-inotify (>= 0.9)
    loofah (2.0.1)
      nokogiri (>= 1.5.9)
    lumberjack (1.0.9)
    mail (2.6.3)
      mime-types (>= 1.16, < 3)
    method_source (0.8.2)
    mime-types (2.4.3)
    mini_portile (0.6.1)
    minitest (5.5.0)
    multi_json (1.10.1)
    multipart-post (2.0.0)
    nenv (0.1.1)
    nested_form (0.3.2)
    net-scp (1.2.1)
      net-ssh (>= 2.6.5)
    net-ssh (2.9.1)
    newrelic_rpm (3.9.8.273)
    nokogiri (1.6.5)
      mini_portile (~> 0.6.0)
    parser (2.2.0)
      ast (>= 1.1, < 3.0)
      slop (~> 3.4, >= 3.4.5)
    pg (0.17.1)
    pg_array_parser (0.0.9)
    poltergeist (1.5.1)
      capybara (~> 2.1)
      cliver (~> 0.3.1)
      multi_json (~> 1.0)
      websocket-driver (>= 0.2.0)
    postgres_ext (2.3.0)
      activerecord (>= 4.0.0)
      arel (>= 4.0.1)
      pg_array_parser (~> 0.0.9)
    powerpack (0.0.9)
    pry (0.10.1)
      coderay (~> 1.1.0)
      method_source (~> 0.8.1)
      slop (~> 3.4)
    pry-rails (0.3.2)
      pry (>= 0.9.10)
    quiet_assets (1.1.0)
      railties (>= 3.1, < 5.0)
    rack (1.6.0)
    rack-cors (0.3.0)
    rack-test (0.6.2)
      rack (>= 1.0)
    rails (4.2.0)
      actionmailer (= 4.2.0)
      actionpack (= 4.2.0)
      actionview (= 4.2.0)
      activejob (= 4.2.0)
      activemodel (= 4.2.0)
      activerecord (= 4.2.0)
      activesupport (= 4.2.0)
      bundler (>= 1.3.0, < 2.0)
      railties (= 4.2.0)
      sprockets-rails
    rails-deprecated_sanitizer (1.0.3)
      activesupport (>= 4.2.0.alpha)
    rails-dom-testing (1.0.5)
      activesupport (>= 4.2.0.beta, < 5.0)
      nokogiri (~> 1.6.0)
      rails-deprecated_sanitizer (>= 1.0.1)
    rails-html-sanitizer (1.0.1)
      loofah (~> 2.0)
    rails_12factor (0.0.3)
      rails_serve_static_assets
      rails_stdout_logging
    rails_serve_static_assets (0.0.3)
    rails_stdout_logging (0.0.3)
    railties (4.2.0)
      actionpack (= 4.2.0)
      activesupport (= 4.2.0)
      rake (>= 0.8.7)
      thor (>= 0.18.1, < 2.0)
    rainbow (2.0.0)
    raindrops (0.13.0)
    rake (10.4.2)
    rb-fsevent (0.9.4)
    rb-inotify (0.9.5)
      ffi (>= 0.5.0)
    rdoc (4.2.0)
      json (~> 1.4)
    ref (1.0.5)
    request_store (1.1.0)
    require_all (1.3.2)
    responders (2.0.2)
      railties (>= 4.2.0.alpha, < 5)
    rollbar (1.3.1)
      multi_json (~> 1.3)
    rspec (3.1.0)
      rspec-core (~> 3.1.0)
      rspec-expectations (~> 3.1.0)
      rspec-mocks (~> 3.1.0)
    rspec-activemodel-mocks (1.0.1)
      activemodel (>= 3.0)
      activesupport (>= 3.0)
      rspec-mocks (>= 2.99, < 4.0)
    rspec-core (3.1.7)
      rspec-support (~> 3.1.0)
    rspec-expectations (3.1.2)
      diff-lcs (>= 1.2.0, < 2.0)
      rspec-support (~> 3.1.0)
    rspec-mocks (3.1.3)
      rspec-support (~> 3.1.0)
    rspec-rails (3.1.0)
      actionpack (>= 3.0)
      activesupport (>= 3.0)
      railties (>= 3.0)
      rspec-core (~> 3.1.0)
      rspec-expectations (~> 3.1.0)
      rspec-mocks (~> 3.1.0)
      rspec-support (~> 3.1.0)
    rspec-support (3.1.2)
    rspec_rails_scaffold_templates (1.0.4)
    rubocop (0.26.1)
      astrolabe (~> 1.3)
      parser (>= 2.2.0.pre.4, < 3.0)
      powerpack (~> 0.0.6)
      rainbow (>= 1.99.1, < 3.0)
      ruby-progressbar (~> 1.4)
    ruby-progressbar (1.7.1)
    ruby2ruby (2.1.3)
      ruby_parser (~> 3.1)
      sexp_processor (~> 4.0)
    ruby_parser (3.5.0)
      sexp_processor (~> 4.1)
    rubyzip (1.1.6)
    sass (3.4.9)
    sass-rails (5.0.0)
      railties (>= 4.0.0, < 5.0)
      sass (~> 3.1)
      sprockets (>= 2.8, < 4.0)
      sprockets-rails (>= 2.0, < 4.0)
      tilt (~> 1.1)
    scrypt (1.2.1)
      ffi-compiler (>= 0.0.2)
      rake
    sdoc (0.4.1)
      json (~> 1.7, >= 1.7.7)
      rdoc (~> 4.0)
    sexp_processor (4.4.4)
    shoulda-matchers (2.7.0)
      activesupport (>= 3.0.0)
    simple_form (3.1.0)
      actionpack (~> 4.0)
      activemodel (~> 4.0)
    simplecov (0.9.1)
      docile (~> 1.1.0)
      multi_json (~> 1.0)
      simplecov-html (~> 0.8.0)
    simplecov-html (0.8.0)
    slim (2.1.0)
      temple (~> 0.6.9)
      tilt (>= 1.3.3, < 2.1)
    slop (3.6.0)
    spring (1.2.0)
    spring-commands-rspec (1.0.4)
      spring (>= 0.9.1)
    sprockets (2.12.3)
      hike (~> 1.2)
      multi_json (~> 1.0)
      rack (~> 1.0)
      tilt (~> 1.1, != 1.3.0)
    sprockets-rails (2.2.2)
      actionpack (>= 3.0)
      activesupport (>= 3.0)
      sprockets (>= 2.8, < 4.0)
    sshkit (1.6.1)
      colorize (>= 0.7.0)
      net-scp (>= 1.1.2)
      net-ssh (>= 2.8.0)
    temple (0.6.10)
    terminal-table (1.4.5)
    therubyracer (0.12.1)
      libv8 (~> 3.16.14.0)
      ref
    thor (0.19.1)
    thread_safe (0.3.4)
    tilt (1.4.1)
    timers (4.0.1)
      hitimes
    traco (3.1.5)
      activerecord (>= 3.0)
    translations_sync (0.4.5)
      ya2yaml
    turbolinks (2.5.3)
      coffee-rails
    tzinfo (1.2.2)
      thread_safe (~> 0.1)
    uglifier (2.6.0)
      execjs (>= 0.3.0)
      json (>= 1.8.0)
    unicorn (4.8.3)
      kgio (~> 2.6)
      rack
      raindrops (~> 0.7)
    unicorn-worker-killer (0.4.3)
      get_process_mem (~> 0)
      unicorn (~> 4)
    websocket-driver (0.5.1)
      websocket-extensions (>= 0.1.0)
    websocket-extensions (0.1.1)
    wice_grid (3.4.11)
      coffee-rails
      kaminari (>= 0.13.0)
    xpath (2.0.0)
      nokogiri (~> 1.3)
    ya2yaml (0.31)
    zeus (0.15.3)
      method_source (>= 0.6.7)

PLATFORMS
  ruby

DEPENDENCIES
  active_model_serializers
  active_record_model_and_rspec_enhanced_templates
  advanced_haml_scaffold_generator
  annotate
  authlogic
  brakeman
  cancancan
  capistrano-passenger
  capistrano-rails
  capistrano-rvm
  capybara
  coffee-rails
  compass-rails
  database_cleaner
  delayed_job_active_record
  email_spec
  factory_girl_fixtures_template
  factory_girl_rails
  faker
  fancy-buttons
  faraday
  font-awesome-rails
  geonames_api
  guard
  guard-rspec
  guard-rubocop
  haml-rails
  html2haml!
  i18n_scaffold_controller_template
  i18n_scaffold_generator
  i18n_yaml_sorter
  jbuilder
  jbuilder_rspec_generator
  jquery-migrate-rails
  jquery-placeholder-rails
  jquery-rails
  jquery-ui-rails
  kaminari
  letter_opener
  nested_form
  newrelic_rpm
  pg
  poltergeist
  postgres_ext
  pry-rails
  quiet_assets
  rack-cors
  rails (~> 4.2)
  rails_12factor
  require_all
  responders (~> 2.0)
  rollbar
  rspec-activemodel-mocks
  rspec-rails
  rspec_rails_scaffold_templates
  rubocop (= 0.26.1)
  rubyzip
  sass-rails
  sdoc
  shoulda-matchers
  simple_form
  simplecov
  spring
  spring-commands-rspec
  sprockets
  therubyracer
  traco
  translations_sync
  turbolinks
  uglifier
  unicorn
  unicorn-worker-killer
  wice_grid
  zeus
```
