### PR TITLE
Reduce specificity of Haml 4.0 version dependency

### DIFF
--- a/html2haml.gemspec
+++ b/html2haml.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'nokogiri', '~> 1.6.0'
   gem.add_dependency 'erubis', '~> 2.7.0'
   gem.add_dependency 'ruby_parser', '~> 3.5'
-  gem.add_dependency 'haml', '~> 4.0.0'
+  gem.add_dependency 'haml', '~> 4.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'minitest', '~> 4.4.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
The Gemspec is overly specific by requiring the `4.0.x` branch of Haml. According to SemVer (which the Haml maintainers have adopted), it should be safe to accept the `4.x` versions of Haml. Thanks.

Edit: I should note that the reason I am proposing this change is that I am trying to install Haml `4.1beta` and am getting this unresolveable dependency tree :-(

```
    haml-rails (>= 0) ruby depends on
      html2haml (>= 1.0.1) ruby depends on
        haml (~> 4.0.0) ruby
```
