### PR TITLE
Reduce specificity of Nokogiri version dependency.

### DIFF
--- a/html2haml.gemspec
+++ b/html2haml.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_dependency 'nokogiri', '~> 1.6.0'
+  gem.add_dependency 'nokogiri', '~> 1.6'
   gem.add_dependency 'erubis', '~> 2.7.0'
   gem.add_dependency 'ruby_parser', '~> 3.5'
   gem.add_dependency 'haml', '~> 4.0'


### PR DESCRIPTION
Nokogiri 1.6 produces deprecation warnings on Ruby 2.4. This is fixed in Nokogiri 1.7.