### PR TITLE
CI against Ruby 2.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install: gem update bundler --no-document
 
 rvm:
   - 2.4.1
-  - 2.3.3
+  - 2.3.4
   - 2.2.7
   - 2.1.10
   - 2.0.0


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/03/30/ruby-2-3-4-released/