### PR TITLE
Relax Haml dependency to allow for newer versions

### DIFF
--- a/html2haml.gemspec
+++ b/html2haml.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'nokogiri', '>= 1.6.0'
   gem.add_dependency 'erubis', '~> 2.7.0'
   gem.add_dependency 'ruby_parser', '~> 3.5'
-  gem.add_dependency 'haml', '~> 4.0'
+  gem.add_dependency 'haml', ['>= 4.0', '< 6']
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'minitest', '>= 4.4.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Haml 5.0.0 beta 2 has been out [since February][1] and since [haml-rails depends on
html2haml][2], it's impossible to test this version out while using haml-rails.

[1]: https://rubygems.org/gems/haml-rails
[2]: https://github.com/olivierlacan/haml-rails/blob/e92e637173361fc7e0aef1885137f9fb7a521714/haml-rails.gemspec#L22