### PR TITLE
Prevent this from eating content after punctuation

### DIFF
--- a/lib/html2haml/html.rb
+++ b/lib/html2haml/html.rb
@@ -350,11 +350,12 @@ module Html2haml
                self.previous.content =~ /\A\s*\Z/ && self.previous.previous.nil?)
             nuke_outer_whitespace = true
           else
-            output << "= succeed #{self.next.content.slice!(/\A[^\s]+/).dump} do\n"
+            next_content = self.next.content
+            output << "= succeed #{next_content.slice!(/\A[^\s]+/).dump} do\n"
             tabs += 1
             output << tabulate(tabs)
-            #empty the text node since it was inserted into the block
-            self.next.content = ""
+            # Set the next content to whatever wasn't added to the succeed statement
+            self.next.content = next_content
           end
         end
 

--- a/test/html2haml_test.rb
+++ b/test/html2haml_test.rb
@@ -365,6 +365,21 @@ HAML
 HTML
   end
 
+  def test_comma_doesnt_nuke_other_content_post_tag
+    assert_equal(<<HAML.rstrip, render(<<HTML))
+#foo
+  Batch
+  = succeed "," do
+    %span Foo
+  and everything else that goes in here.
+HAML
+<div id="foo">
+  Batch
+  <span>Foo</span>, and everything else that goes in here.
+</div>
+HTML
+  end
+
   def test_haml_tags_should_be_on_new_line_after_tag_with_blank_content
     xml  = "<weight> </weight>\n<pages>102</pages>"
     haml = "%weight\n%pages 102"


### PR DESCRIPTION
So I had some content that looked like this:

```
<p>Lorem ipsum dolor sit amet, per nostro aeterno partiendo an, ei iudico repudiandae eum. Ne error populo quaerendum cum. Ius saepe pertinacia eu. Duo et luptatum apeirian. Nec hinc probatus <a href="#">explicari eu</a>, te pro simul Important Content Here. Populo vocent est ne.</p>
```

... and it was getting converted incorrectly as:

```
%p
  Lorem ipsum dolor sit amet, per nostro aeterno partiendo an, ei iudico repudiandae eum. Ne error populo quaerendum cum. Ius saepe pertinacia eu. Duo et luptatum apeirian. Nec hinc probatus
  = succeed "," do
    %a{:href => "#"} explicari eu
```

I've updated the code that deals with the `= succeed ","` part, so the content after the link doesn't get swallowed up. Hope this helps someone other than me! 