### PR TITLE
Parse Ruby code with currently running version of Ruby syntax parser

### DIFF
--- a/lib/html2haml/html.rb
+++ b/lib/html2haml/html.rb
@@ -439,7 +439,7 @@ module Html2haml
 
       def attribute_value_can_be_bare_ruby?(value)
         begin
-          ruby = RubyParser.new.parse(value)
+          ruby = RubyParser.for_current_ruby.parse(value)
         rescue Racc::ParseError, RubyParser::SyntaxError
           return false
         end

--- a/lib/html2haml/html/erb.rb
+++ b/lib/html2haml/html/erb.rb
@@ -98,7 +98,7 @@ module Html2haml
       # @param code [String] Ruby code to check
       # @return [Boolean]
       def valid_ruby?(code)
-        RubyParser.new.parse(code)
+        RubyParser.for_current_ruby.parse(code)
       rescue Racc::ParseError, RubyParser::SyntaxError
         false
       end


### PR DESCRIPTION
Currently, html2haml internally uses `RubyParser.new` to parse interpolated Ruby code. For instance, it uses Ruby 3.1 syntax parser as of today, regardless of the actual Ruby version of the user's current project.

Instead, it'd be natural to use the parser for currently running Ruby version.