### PR TITLE
s/MiniTest/Minitest/

### DIFF
--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ErbTest < MiniTest::Unit::TestCase
+class ErbTest < Minitest::Unit::TestCase
   def test_erb
     assert_equal '- foo = bar', render_erb('<% foo = bar %>')
     assert_equal '- foo = bar', render_erb('<% foo = bar -%>')

--- a/test/html2haml_test.rb
+++ b/test/html2haml_test.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 require 'test_helper'
 
-class Html2HamlTest < MiniTest::Unit::TestCase
+class Html2HamlTest < Minitest::Unit::TestCase
   def test_empty_render_should_remain_empty
     assert_equal '', render('')
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ end
 
 require "bundler/setup"
 require "minitest/autorun"
+require "minitest/unit"
 require "html2haml"
 require 'html2haml/html'
 require 'html2haml/html/erb'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require "html2haml"
 require 'html2haml/html'
 require 'html2haml/html/erb'
 
-class MiniTest::Unit::TestCase
+class Minitest::Unit::TestCase
   protected
   def render(text, options = {})
     Html2haml::HTML.new(text, options).render.rstrip


### PR DESCRIPTION
This proposed change replaces the old 'MiniTest' namespace with the more modern 'Minitest'. The old one is not recognized by the minitest version shipped with ruby3.3.